### PR TITLE
Fitas and barred o-s confused with barred Cyrillic 'o'

### DIFF
--- a/dev/ortho/kir-CYR.spellrelax.twol
+++ b/dev/ortho/kir-CYR.spellrelax.twol
@@ -2,6 +2,8 @@ Alphabet
 
  е:е е:e ! things that should be analysed as e
  ё:ё ё:е ё:e ! things that should be analysed as ё
+ ө:ө ѳ:ө ɵ:ө ! things that should be analysed as ө (Cyrillic fita U+0473, Latin barred o U+0275)
+ Ө:Ө Ѳ:Ө Ɵ:Ө ! things that should be analysed as Ө (Cyrillic Fita U+0472, Latin barred O U+019F)
 
 ;
 


### PR DESCRIPTION
Hi! 

This addresses #14 (fita and Latin barred-O in spellrelax).

ѳ/Ѳ (Cyrillic fita, U+0473/U+0472) and ɵ/Ɵ (Latin barred-o, U+0275/U+019F) are visually identical to Cyrillic ө/Ө and sometimes get typed in its place. This adds them to the CYR spellrelax so they're accepted and analysed as ө/Ө, following the existing е/ё pattern in the same file. 

Thanks!