### PR TITLE
editdist.py made python-version-agnostic + ospell is allowed to be enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,3 @@
 /.DS_Store
 /*-*.prob
 /test/*-output.txt
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 /.DS_Store
 /*-*.prob
 /test/*-output.txt
+.idea

--- a/Makefile.am
+++ b/Makefile.am
@@ -164,7 +164,7 @@ $(LANG1).zhfst: .deps/acceptor.default.hfst .deps/errmodel.default.hfst
 	zip -j $@ .deps/acceptor.default.hfst .deps/errmodel.default.hfst speller/index.xml
 
 .deps/errmodel.default.hfst: .deps/words.default.hfst .deps/strings.default.hfst
-	python dev/editdist.py -v -s -d 1 -e '@0@' -i speller/editdist.default.txt -a .deps/acceptor.default.hfst \
+	$(PYTHON) dev/editdist.py -v -s -d 1 -e '@0@' -i speller/editdist.default.txt -a .deps/acceptor.default.hfst \
 	| hfst-txt2fst  -e '@0@' -o .deps/editdist.default.hfst
 	hfst-disjunct .deps/strings.default.hfst .deps/editdist.default.hfst \
 	| hfst-minimise | hfst-repeat -f 1 -t 2 -o .deps/editstrings.default.hfst
@@ -212,9 +212,9 @@ apertium_kir_srcdir=$(prefix)/share/apertium/$(BASENAME)/
 
 EXTRA_TARGETS=
 
-#if HAVE_HFSTOSPELL
+if HAVE_HFSTOSPELL
 EXTRA_TARGETS += $(LANG1).zhfst
-#endif # HAVE_HFSTOSPELL
+endif
 
 apertium_kir_DATA=$(TARGETS_COMMON) $(EXTRA_TARGETS) $(LANG1).prob
 

--- a/configure.ac
+++ b/configure.ac
@@ -4,6 +4,12 @@ AC_INIT([Apertium Kyrgyz], [0.1.1], [apertium-stuff@lists.sourceforge.net], [ape
 AM_INIT_AUTOMAKE
 AC_PROG_AWK
 
+dnl Find a Python interpreter for the speller helper (dev/editdist.py),
+dnl which now runs under both Python 2 and 3. Prefer python3, then a
+dnl generic python, then python2. Can be overridden with PYTHON=... .
+AC_ARG_VAR([PYTHON], [Python interpreter to use for build helper scripts])
+AC_PATH_PROGS([PYTHON], [python3 python python2], [python])
+
 dnl HFST support
 AH_TEMPLATE(HAVE_HFSTOSPELL, [Have HFSTOSPELL])
 AC_ARG_ENABLE(ospell, AC_HELP_STRING([--enable-ospell],

--- a/dev/editdist.py
+++ b/dev/editdist.py
@@ -1,12 +1,21 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # see editdist.py --help for usage
 
+from __future__ import print_function
 
 import sys
 import struct
+import io
 import codecs
 from optparse import OptionParser
+
+# Python 2/3 compatibility: in Python 3 str is already text and `unicode`
+# does not exist, so fall back to str there.
+try:
+    text_type = unicode
+except NameError:
+    text_type = str
 
 usage_string = "usage: %prog [options] alphabet"
 
@@ -67,7 +76,7 @@ class Header:
     
     def __init__(self, file):
         bytes = file.read(5) # "HFST\0"
-        if str(struct.unpack_from("<5s", bytes, 0)) == "('HFST\\x00',)":
+        if struct.unpack_from("<5s", bytes, 0)[0] == b'HFST\x00':
             # just ignore any hfst3 header
             remaining = struct.unpack_from("<H", file.read(3), 0)[0]
             self.handle_hfst3_header(file, remaining)
@@ -99,14 +108,14 @@ class Alphabet:
     """Read and provide interface to alphabet"""
 
     def __init__(self, file, number_of_symbols):
-        stderr_u8 = codecs.getwriter('utf-8')(sys.stderr)
+        stderr_u8 = codecs.getwriter('utf-8')(getattr(sys.stderr, 'buffer', sys.stderr))
         self.keyTable = [] # list of unicode objects, use foo.encode("utf-8") to print
         for x in range(number_of_symbols):
-            symbol = ""
+            symbol = b""
             while True:
                 byte = file.read(1)
-                if byte == '\0': # a symbol has ended
-                    symbol = unicode(symbol, "utf-8")
+                if byte == b'\0': # a symbol has ended
+                    symbol = symbol.decode("utf-8")
                     if len(symbol) != 1:
                         stderr_u8.write("Ignored symbol " + symbol + "\n")
                     else:
@@ -150,20 +159,20 @@ exclusions = set()
 
 if options.inputfile == None and options.alphabetfile == None \
         and len(args) == 0:
-    print "Specify at least one of INPUT, ALPHABET or alphabet string"
+    print("Specify at least one of INPUT, ALPHABET or alphabet string")
     sys.exit()
 if len(args) > 1:
-    print "Too many options!"
+    print("Too many options!")
     sys.exit()
 
 if options.inputfile != None:
     try:
-        inputfile = open(options.inputfile)
+        inputfile = io.open(options.inputfile, encoding='utf-8')
     except IOError:
-        print "Couldn't open " + options.inputfile
+        print("Couldn't open " + options.inputfile)
         sys.exit()
     while True:
-        line = unicode(inputfile.readline(), 'utf-8')
+        line = inputfile.readline()
         if line in ("@@\n", ""):
             break
         if line.strip() != "":
@@ -174,14 +183,17 @@ if options.inputfile != None:
                 continue
             if '\t' in line:
                 weight = float(line.split('\t')[1])
-                symbol = linesplit('\t')[0]
+                symbol = line.split('\t')[0]
             else:
                 weight = 0.0
                 symbol = line.strip("\n")
             alphabet[symbol] = weight
 
 if len(args) == 1:
-    for c in unicode(args[0], 'utf-8'):
+    arg = args[0]
+    if not isinstance(arg, text_type):  # bytes in Python 2
+        arg = arg.decode('utf-8')
+    for c in arg:
         if c not in alphabet.keys() and c not in exclusions:
             alphabet[c] = 0.0
 if options.alphabetfile != None:
@@ -191,11 +203,13 @@ if options.alphabetfile != None:
     for c in filter(lambda x: x.strip() != '', ol_alphabet.keyTable[:]):
         if c not in alphabet.keys() and c not in exclusions:
             alphabet[c] = 0.0
-epsilon = unicode(options.epsilon, 'utf-8')
+epsilon = options.epsilon
+if not isinstance(epsilon, text_type):  # bytes in Python 2
+    epsilon = epsilon.decode('utf-8')
 OTHER = u'@_UNKNOWN_SYMBOL_@'
 
-def p(string): # stupid python, or possibly stupid me
-    return string.encode('utf-8')
+def p(string): # keep symbols as text; encoding (if any) happens at output time
+    return string
 
 def maketrans(from_st, to_st, from_sy, to_sy, weight):
     return str(from_st) + "\t" + str(to_st) + "\t" + p(from_sy) + "\t" + p(to_sy) + "\t" + str(weight)
@@ -336,20 +350,24 @@ if options.inputfile != None:
             continue
         if line == "":
             break
-        transducer.process(unicode(line, "utf-8"))
+        transducer.process(line)
 
 transducer.generate()
 transducer.make_transitions()
-for transition in transducer.transitions:
-    print transition
 
-stderr_u8 = codecs.getwriter('utf-8')(sys.stderr)
+# Write UTF-8 output in both Python 2 and 3. In Python 3 we use the byte
+# buffer underneath sys.stdout; in Python 2 sys.stdout takes bytes directly.
+stdout_bytes = getattr(sys.stdout, 'buffer', sys.stdout)
+for transition in transducer.transitions:
+    stdout_bytes.write((transition + "\n").encode('utf-8'))
+
+stderr_u8 = codecs.getwriter('utf-8')(getattr(sys.stderr, 'buffer', sys.stderr))
 
 if options.verbose:
     stderr_u8.write("\n" + str(max(transducer.skipstate, transducer.swapstate)) + " states and " + str(len(transducer.transitions)) + " transitions written for\n"+
                      "distance " + str(options.distance) + " and base alphabet size " + str(len(transducer.alphabet)) +"\n\n")
     stderr_u8.write("The alphabet was:\n")
-    for symbol, weight in alphabet.iteritems():
+    for symbol, weight in alphabet.items():
         stderr_u8.write(symbol + "\t" + str(weight) + "\n")
     if len(exclusions) != 0:
         stderr_u8.write("The exclusions were:\n")


### PR DESCRIPTION
Outside contributor from a related PR https://github.com/apertium/apertium-kir/pull/18 here. 

The HFST speller (kir.zhfst) was broken in two compounding ways: dev/editdist.py (which builds the error model) is Python 2, so under a Python-3 python it died with a print SyntaxError — and since the Makefile pipes it into hfst-txt2fst, the failure was masked and the speller got an empty error model. Separately, the #if HAVE_HFSTOSPELL guard in Makefile.am is written with #-comments, so Automake ignored it: --enable-ospell was a no-op and the speller was force-built every time. This makes the script run under both Python 2 and 3 (with configure detecting the interpreter, overridable via PYTHON=), and switches the guard to real if HAVE_HFSTOSPELL/endif. Verified that the speller is now excluded by default and, with --enable-ospell, builds with a working ~28k-state error model. 

Thanks!

- - - 

The HFST spellchecker (kir.zhfst) seems to have been effectively broken in two ways.
 
1. `dev/editdist.py`, which generates the speller error model, used Python-2-only syntax, so under a Python-3 `python` it died with a `print SyntaxError`. Because the Makefile pipes it into hfst-txt2fst, the crash was masked (the pipe still exited 0) and the speller was built with an empty error model.
 
   Made the script run unmodified under both Python 2 and 3:
   * from __future__ import print_function; print statements -> print()
   * a text_type = unicode/str shim instead of bare unicode()
   * read the UTF-8 input file via io.open(encoding='utf-8') and decode argv-derived strings only when they are bytes (Python 2)
   * read the optimised-lookup alphabet as bytes and .decode() per symbol; compare the HFST3 magic against b'HFST\x00'
   * write UTF-8 output via sys.stdout.buffer when present (Python 3) and  sys.stdout otherwise (Python 2)
   * dict.iteritems() -> items(); also fix a latent NameError  ('linesplit' -> 'line.split')
 
   Made the interpreter environment-dependent  
   `python`: configure.ac gains `AC_PATH_PROGS([PYTHON], [python3 python python2]) (overridable with PYTHON=...)`, and Makefile.am calls  `$(PYTHON) dev/editdist.py`.
 
2. The Automake guard around building the speller was written with
   '#'-comments:
 
       #if HAVE_HFSTOSPELL
       EXTRA_TARGETS += $(LANG1).zhfst
       #endif
 
   Automake treats those as ordinary comments, so the conditional was ignored and kir.zhfst was always a default target -- making `--enable-ospell` a no-op and forcing the (previously empty-error-model) speller on every build, even without the ospell toolchain. Uses real Automake 'if HAVE_HFSTOSPELL' / 'endif'. The AM_CONDITIONAL already exists in configure.ac.
 
Verified: without `--enable-ospell` the speller is no longer built; with `--enable-ospell`, `make kir.zhfst` produces a working speller with a real ~28k-state error model that correctly distinguishes in- vs out-of-lexicon words (e.g. 'китеп' vs 'китеб'). The script's output is byte-for-byte identical to a straight Python-3 port.

- - - 

Important detail: the ATT text differs between Python 2 and 3 (different state-numbering, due to dict/set iteration order)
But the compiled transducer is identical in behavior — `hfst-compare` says they should be equal.