### PR TITLE
configure.ac: modernise two obsolete autoconf macros

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ AC_PROG_AWK
 
 dnl HFST support
 AH_TEMPLATE(HAVE_HFSTOSPELL, [Have HFSTOSPELL])
-AC_ARG_ENABLE(ospell, AC_HELP_STRING([--enable-ospell],
+AC_ARG_ENABLE(ospell, AS_HELP_STRING([--enable-ospell],
         [enable HFST spellchecking backend]),
         [hfstospell=${enableval}], [hfstospell=no])
 dnl must be AS_IF for some aclocals to pick PKG_CHECK_MODULES somehow.
@@ -28,4 +28,5 @@ PKG_CHECK_MODULES(REGTEST, apertium-regtest >= 0.0.1, [],
 
 AP_MKINCLUDE
 
-AC_OUTPUT([Makefile apertium-kir.pc])
+AC_CONFIG_FILES([Makefile apertium-kir.pc])
+AC_OUTPUT


### PR DESCRIPTION
Hello all,

proposing a small cosmetic cleanup. `autoreconf` currently emits two deprecation warnings (AC_HELP_STRING is obsolete; AC_OUTPUT should be used without arguments). This swaps in AS_HELP_STRING and splits AC_OUTPUT([...]) into AC_CONFIG_FILES + bare AC_OUTPUT. Pure modernization, no behavioral change — `configure` still produces the Makefile and .pc, and autoreconf is now warning-free. 

Thanks!

P.S.: other emitted warnings during build process are too scary to eliminate, may change behaviour of the tool, need to know all the details of the analyzer much better than I do.

- - -
 
autoreconf emits two deprecation warnings:
 
```
  configure.ac:9: warning: The macro `AC_HELP_STRING' is obsolete.
  configure.ac:31: warning: AC_OUTPUT should be used without arguments.
``` 

Replacing AC_HELP_STRING with its current name AS_HELP_STRING, and splitting the argument form AC_OUTPUT([Makefile apertium-kir.pc]) into AC_CONFIG_FILES([Makefile apertium-kir.pc]) followed by a bare AC_OUTPUT. Both are pure modernisations with identical behaviour; `configure` still generates Makefile and apertium-kir.pc and the --enable-ospell help text is unchanged. autoreconf is now warning-free.